### PR TITLE
Make the macros aware of the row/col they were pressed at

### DIFF
--- a/src/Keyboardio-Macros.cpp
+++ b/src/Keyboardio-Macros.cpp
@@ -1,7 +1,7 @@
 #include "Keyboardio-Macros.h"
 
 __attribute__((weak))
-const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
+const macro_t *macroAction(uint8_t macroIndex, byte row, byte col, uint8_t keyState) {
     return MACRO_NONE;
 }
 
@@ -51,7 +51,7 @@ static Key handleMacroEvent(Key mappedKey, byte row, byte col, uint8_t keyState)
     if (!key_toggled_on(keyState))
       return Key_NoKey;
 
-    const macro_t *m = macroAction(mappedKey.keyCode, keyState);
+    const macro_t *m = macroAction(mappedKey.keyCode, row, col, keyState);
 
     Macros.play(m);
     return Key_NoKey;

--- a/src/Keyboardio-Macros.cpp
+++ b/src/Keyboardio-Macros.cpp
@@ -1,9 +1,11 @@
 #include "Keyboardio-Macros.h"
 
 __attribute__((weak))
-const macro_t *macroAction(uint8_t macroIndex, byte row, byte col, uint8_t keyState) {
+const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
     return MACRO_NONE;
 }
+
+byte Macros_::row, Macros_::col;
 
 void Macros_::play(const macro_t *macro_p) {
     macro_t macro = END;
@@ -51,7 +53,9 @@ static Key handleMacroEvent(Key mappedKey, byte row, byte col, uint8_t keyState)
     if (!key_toggled_on(keyState))
       return Key_NoKey;
 
-    const macro_t *m = macroAction(mappedKey.keyCode, row, col, keyState);
+    Macros_::row = row;
+    Macros_::col = col;
+    const macro_t *m = macroAction(mappedKey.keyCode, keyState);
 
     Macros.play(m);
     return Key_NoKey;

--- a/src/Keyboardio-Macros.h
+++ b/src/Keyboardio-Macros.h
@@ -5,7 +5,7 @@
 #include "MacroKeyDefs.h"
 #include "MacroSteps.h"
 
-const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState);
+const macro_t *macroAction(uint8_t macroIndex, byte row, byte col, uint8_t keyState);
 
 class Macros_ : public KeyboardioPlugin {
   public:

--- a/src/Keyboardio-Macros.h
+++ b/src/Keyboardio-Macros.h
@@ -5,7 +5,7 @@
 #include "MacroKeyDefs.h"
 #include "MacroSteps.h"
 
-const macro_t *macroAction(uint8_t macroIndex, byte row, byte col, uint8_t keyState);
+const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState);
 
 class Macros_ : public KeyboardioPlugin {
   public:
@@ -14,6 +14,8 @@ class Macros_ : public KeyboardioPlugin {
     virtual void begin(void) final;
 
     void play(const macro_t *macro_p);
+
+    static byte row, col;
 };
 
 extern Macros_ Macros;


### PR DESCRIPTION
This will be useful for cases where one wants to do something with the coordinates, like lighting up the LED under the macro key.